### PR TITLE
Ga update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "gh-pages": "^2.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-ga": "^3.3.1",
         "react-router": "^5.0.1",
         "react-router-dom": "^5.0.1",
         "react-scripts": "^5.0.1",
@@ -14558,15 +14557,6 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
-    },
-    "node_modules/react-ga": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.1.tgz",
-      "integrity": "sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==",
-      "peerDependencies": {
-        "prop-types": "^15.6.0",
-        "react": "^15.6.2 || ^16.0 || ^17 || ^18"
-      }
     },
     "node_modules/react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.3.0",
@@ -11,7 +11,6 @@
     "gh-pages": "^2.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-ga": "^3.3.1",
     "react-router": "^5.0.1",
     "react-router-dom": "^5.0.1",
     "react-scripts": "^5.0.1",

--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-MGR746ZF9N"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-MGR746ZF9N');
+    </script>
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -19,7 +27,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Serena Gutierrez</title>
+    <!-- <title>Serena Gutierrez</title> -->
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import ReactGA from 'react-ga'
 import { Route, HashRouter } from 'react-router-dom'
 import './styles/App.css'
 import Header from './components/Header.js'
@@ -8,13 +7,6 @@ import Projects from './pages/Projects.js'
 import Footer from './components/Footer.js'
 
 class App extends React.Component {
-  constructor (props) {
-    super(props)
-
-    ReactGA.initialize('UA-143101404-1')
-    ReactGA.pageview(window.location.pathname)
-  }
-
   render () {
     return (
       <HashRouter>

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,8 +1,23 @@
 import React from 'react'
+import { updatePageTitle } from '../utils/updatePageTitle'
 import '../styles/home.scss'
 import me from '../assets/me.jpg'
 
 class Home extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      hasTitleUpdate: false
+    }
+  }
+
+  componentDidMount () {
+    if (!this.hasTitleUpdate) {
+      updatePageTitle()
+      this.hasTitleUpdate = true
+    }
+  }
+
   render () {
     return (
             <div>

--- a/src/pages/Projects.js
+++ b/src/pages/Projects.js
@@ -1,7 +1,22 @@
 import React from 'react'
 import Card from '../components/Card.js'
-
+import { updatePageTitle } from '../utils/updatePageTitle.js'
 class Project extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      hasTitleUpdate: false
+    }
+  }
+
+  componentDidMount () {
+    if (!this.hasTitleUpdate) {
+      console.log('In projects, updatingPageTitle')
+      updatePageTitle('Projects')
+      this.hasTitleUpdate = true
+    }
+  }
+
   render () {
     return (
       <div>

--- a/src/pages/Projects.js
+++ b/src/pages/Projects.js
@@ -11,7 +11,6 @@ class Project extends React.Component {
 
   componentDidMount () {
     if (!this.hasTitleUpdate) {
-      console.log('In projects, updatingPageTitle')
       updatePageTitle('Projects')
       this.hasTitleUpdate = true
     }

--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -18,25 +18,25 @@ const isLocalhost = Boolean(
     window.location.hostname.match(
       /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
     )
-);
+)
 
-export function register(config) {
+export function register (config) {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
-    const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href);
+    const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href)
     if (publicUrl.origin !== window.location.origin) {
       // Our service worker won't work if PUBLIC_URL is on a different origin
       // from what our page is served on. This might happen if a CDN is used to
       // serve assets; see https://github.com/facebook/create-react-app/issues/2374
-      return;
+      return
     }
 
     window.addEventListener('load', () => {
-      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`
 
       if (isLocalhost) {
         // This is running on localhost. Let's check if a service worker still exists or not.
-        checkValidServiceWorker(swUrl, config);
+        checkValidServiceWorker(swUrl, config)
 
         // Add some additional logging to localhost, pointing developers to the
         // service worker/PWA documentation.
@@ -44,24 +44,24 @@ export function register(config) {
           console.log(
             'This web app is being served cache-first by a service ' +
               'worker. To learn more, visit https://bit.ly/CRA-PWA'
-          );
-        });
+          )
+        })
       } else {
         // Is not localhost. Just register service worker
-        registerValidSW(swUrl, config);
+        registerValidSW(swUrl, config)
       }
-    });
+    })
   }
 }
 
-function registerValidSW(swUrl, config) {
+function registerValidSW (swUrl, config) {
   navigator.serviceWorker
     .register(swUrl)
     .then(registration => {
       registration.onupdatefound = () => {
-        const installingWorker = registration.installing;
+        const installingWorker = registration.installing
         if (installingWorker == null) {
-          return;
+          return
         }
         installingWorker.onstatechange = () => {
           if (installingWorker.state === 'installed') {
@@ -72,38 +72,38 @@ function registerValidSW(swUrl, config) {
               console.log(
                 'New content is available and will be used when all ' +
                   'tabs for this page are closed. See https://bit.ly/CRA-PWA.'
-              );
+              )
 
               // Execute callback
               if (config && config.onUpdate) {
-                config.onUpdate(registration);
+                config.onUpdate(registration)
               }
             } else {
               // At this point, everything has been precached.
               // It's the perfect time to display a
               // "Content is cached for offline use." message.
-              console.log('Content is cached for offline use.');
+              console.log('Content is cached for offline use.')
 
               // Execute callback
               if (config && config.onSuccess) {
-                config.onSuccess(registration);
+                config.onSuccess(registration)
               }
             }
           }
-        };
-      };
+        }
+      }
     })
     .catch(error => {
-      console.error('Error during service worker registration:', error);
-    });
+      console.error('Error during service worker registration:', error)
+    })
 }
 
-function checkValidServiceWorker(swUrl, config) {
+function checkValidServiceWorker (swUrl, config) {
   // Check if the service worker can be found. If it can't reload the page.
   fetch(swUrl)
     .then(response => {
       // Ensure service worker exists, and that we really are getting a JS file.
-      const contentType = response.headers.get('content-type');
+      const contentType = response.headers.get('content-type')
       if (
         response.status === 404 ||
         (contentType != null && contentType.indexOf('javascript') === -1)
@@ -111,25 +111,25 @@ function checkValidServiceWorker(swUrl, config) {
         // No service worker found. Probably a different app. Reload the page.
         navigator.serviceWorker.ready.then(registration => {
           registration.unregister().then(() => {
-            window.location.reload();
-          });
-        });
+            window.location.reload()
+          })
+        })
       } else {
         // Service worker found. Proceed as normal.
-        registerValidSW(swUrl, config);
+        registerValidSW(swUrl, config)
       }
     })
     .catch(() => {
       console.log(
         'No internet connection found. App is running in offline mode.'
-      );
-    });
+      )
+    })
 }
 
-export function unregister() {
+export function unregister () {
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker.ready.then(registration => {
-      registration.unregister();
-    });
+      registration.unregister()
+    })
   }
 }

--- a/src/utils/updatePageTitle.js
+++ b/src/utils/updatePageTitle.js
@@ -1,0 +1,14 @@
+const name = 'Serena Gutierrez'
+
+/**
+ * Updates the page title. If pageTitle is passed in, it will display `portfolio owner name - pageTitle`
+ * Otherwise the page title will just be the portfolio owner name.
+ * @param {string} pageTitle - string to be appended to page title
+ */
+export function updatePageTitle (pageTitle = '') {
+  const newPageTitle = pageTitle ? `${name} - ${pageTitle}` : `${name}`
+  document.title = newPageTitle
+
+  // Google Analytics 4, tracking page title on view
+  window.gtag('event', 'page_view', { page_title: newPageTitle })
+}


### PR DESCRIPTION
Updating to Google Analytics 4, removed ReactGA, which (at this time) doesn't have support for GA4. Sidenote: Checked out reactga4 as well, but it didn't seem to work with GA4's g-tags. 

Added functionality to update page title. GA4 doesn't seem to track my full path (possibly due to the nature of SPA & client-side routing?), so added manual `window.gtag` to track page title on view. 